### PR TITLE
chore: use debug instead of console log for webhook signature logging

### DIFF
--- a/src/resources/webhooks.ts
+++ b/src/resources/webhooks.ts
@@ -2,7 +2,7 @@
 
 import { APIResource } from 'orb-billing/resource';
 import { createHmac } from 'crypto';
-import { getRequiredHeader, HeadersLike } from 'orb-billing/core';
+import { debug, getRequiredHeader, HeadersLike } from 'orb-billing/core';
 
 export class Webhooks extends APIResource {
   /**
@@ -123,7 +123,7 @@ export class Webhooks extends APIResource {
     const encoder = new globalThis.TextEncoder();
     for (const versionedSignature of passedSignatures) {
       const [version, signature] = versionedSignature.split('=');
-      console.log({ version, signature, expectedSignature, computedSignature });
+      debug('verifySignature', { version, signature, expectedSignature, computedSignature });
 
       if (version !== 'v1') {
         continue;


### PR DESCRIPTION
Looks like the `console.log` slipped through, which is currently logging webhook signatures on every verification - switched to `debug` method.