### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "repository": "github:orbcorp/orb-node",
+  "homepage": "https://github.com/orbcorp/orb-node#readme",
+  "bugs": {
+    "url": "https://github.com/orbcorp/orb-node/issues"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
## Summary
- add npm homepage metadata for the package README
- add npm bugs metadata pointing to the public issue tracker

## Validation
- node -e "const p=require('./package.json'); if (p.name !== 'orb-billing' || p.homepage !== 'https://github.com/orbcorp/orb-node#readme' || p.bugs?.url !== 'https://github.com/orbcorp/orb-node/issues') process.exit(1)"
- node scripts/utils/make-dist-package-json.cjs preserves homepage and bugs metadata
- git diff --check